### PR TITLE
Change Kumakk personalities

### DIFF
--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -837,7 +837,7 @@ fleet "Kumakk Security"
 	names "Kumakk Security"
 	personality
 		confusion 15
-		heroic opportunistic
+		heroic opportunistic frugal
 	variant 10
 		Akolucor
 	variant 10
@@ -857,7 +857,7 @@ fleet "Kumakk Heavy Security"
 	names "Kumakk Security"
 	personality
 		confusion 12
-		heroic
+		heroic opportunistic frugal
 	variant 10
 		Akolucor 2
 	variant 10


### PR DESCRIPTION
When the Akralva attack the Kumakk, massive swarms of projectiles appear. Missiles are wasted on enemies that would already be overkilled. This PR makes the Kumakk Security fleets have the `frugal` personality, and therefore they will not attack until they are damaged or outnumbered.
Also, the Kumakk Heavy Security fleet has the `opportunistic` personality added, as the Kumakk Security fleet has that too.

### _**WRONG BRANCH—ALSO REJECTED**_